### PR TITLE
Revert "Update RIL on proprietary-files.txt"

### DIFF
--- a/proprietary-files.txt
+++ b/proprietary-files.txt
@@ -54,7 +54,6 @@ bin/qmiproxy
 bin/cnd
 bin/ds_fmc_appd
 lib/libril.so
-lib/libril-qc-qmi-1.so
 lib/libril-qcril-hook-oem.so
 lib/libsecril-client.so
 lib/libqmi_client_griffon.so


### PR DESCRIPTION
Reverts Arubadel/android_device_delos3geur#1
libril-qc-qmi-1.so is already included 

sorry my mistake